### PR TITLE
Update the call method so that it can be used for downloading attachments

### DIFF
--- a/grist_api/grist_api.py
+++ b/grist_api/grist_api.py
@@ -103,7 +103,7 @@ class GristDocAPI(object):
           raise requests.HTTPError(err_msg, response=resp)
         else:
           raise resp.raise_for_status()
-      return resp.json()
+      return resp
 
   def fetch_table(self, table_name, filters=None):
     """
@@ -118,7 +118,7 @@ class GristDocAPI(object):
       query = '?filter=' + quote_plus(json.dumps(
         {k: [to_grist(v)] for k, v in viewitems(filters)}, sort_keys=True))
 
-    columns = self.call('tables/%s/data%s' % (table_name, query))
+    columns = self.call('tables/%s/data%s' % (table_name, query)).json()
     # convert columns to rows
     Record = namedtuple(table_name, columns.keys())   # pylint: disable=invalid-name
     count = len(columns['id'])
@@ -145,7 +145,7 @@ class GristDocAPI(object):
     results = []
     for data in call_data:
       log.info("add_records %s %s", table_name, desc_col_values(data))
-      results.extend(self.call('tables/%s/data' % table_name, json_data=data) or [])
+      results.extend(self.call('tables/%s/data' % table_name, json_data=data).json() or [])
     return results
 
   def delete_records(self, table_name, record_ids, chunk_size=None):


### PR DESCRIPTION
When downloading an attachment, with an url of the form https://{subdomain}.getgrist.com/api/docs/{docId}/attachments/{attachmentId}/download, the returned content-type is not json.

Reference to grist documentation :
https://support.getgrist.com/api/#tag/attachments/operation/downloadAttachment.

Here is an example of utilization 

```
def download_attachement(server, doc_id, id)
   fp = tempfile.NamedTemporaryFile(suffix='pdf', delete=False)
   api = GristDocAPI(doc_id, server=server)
   r = api.call(f'attachments/{id}/download', method='GET')
   fp.write(r.content)
   fp.close()
```